### PR TITLE
Removing that 'undeclared identifier' warning

### DIFF
--- a/nobu.h
+++ b/nobu.h
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #define CC "cc"


### PR DESCRIPTION
Removing that single `Use of undeclared identifier 'waitpid'` warning.